### PR TITLE
Handle backquotes better

### DIFF
--- a/macrostep.el
+++ b/macrostep.el
@@ -618,7 +618,7 @@ expansion will not be fontified.  See also
       (cond ((and (eq head 'quote)	; quote
 		  (= (length sexp) 2))
 	     (insert "'")
-	     (macrostep-print-sexp (cadr sexp)))
+	     (macrostep-print-sexp (cadr sexp) t))
 
 	    ((and (memq head '(\, \,@)) ; unquote
 		  (= (length sexp) 2))


### PR DESCRIPTION
I think this handles backquotes properly now.  There's a new option on macrostep-print-sexp to suppress the fontifying of backquoted macro forms since it makes no sense to expand a macro there.
