### PR TITLE
Continue to extend macrostep-expansion-highlight-face to window edge

### DIFF
--- a/macrostep.el
+++ b/macrostep.el
@@ -340,8 +340,12 @@ buffer.")
   :group 'macrostep)
 
 (defface macrostep-expansion-highlight-face
-  '((((min-colors 16581375) (background light)) :background "#eee8d5")
-    (((min-colors 16581375) (background dark)) :background "#222222"))
+  `((((min-colors 16581375) (background light))
+     ,@(and (>= emacs-major-version 27) '(:extend t))
+     :background "#eee8d5")
+    (((min-colors 16581375) (background dark))
+     ,@(and (>= emacs-major-version 27) '(:extend t))
+     :background "#222222"))
   "Face for macro-expansion highlight."
   :group 'macrostep)
 


### PR DESCRIPTION
Due to a breaking change we have to request this explicitly in
Emacs 27.  Earlier Emacs versions do the right thing by default.

If the effect of a face does not extend to the edge of the window,
then attributes such as the background color or underline cease to
be used for more that the width of a single character, which is not
appropriate for a face intended to highlight a block of lines.

See https://debbugs.gnu.org/cgi/bugreport.cgi?bug=37774 if you want
all the gory details.