### PR TITLE
Avoid positional arguments to define-minor-mode

### DIFF
--- a/macrostep.el
+++ b/macrostep.el
@@ -497,7 +497,8 @@ Use \\[macrostep-collapse-all] or collapse all visible expansions to
 quit and return to normal editing.
 
 \\{macrostep-keymap}"
-  nil " Macro-Stepper"
+  :init-value nil
+  :lighter " Macro-Stepper"
   :keymap macrostep-keymap
   :group macrostep
   (if macrostep-mode


### PR DESCRIPTION
Back in Emacs-21.1, `define-minor-mode` grew keyword arguments to
replace its old positional arguments.  Starting with Emacs-28.1
a warning will be omitted if positional arguments are still used.

For backward compatibility one keyword argument has to be provided
if a function body is provided (as otherwise the non-keyword value
argument and the body could not be told apart).