### PR TITLE
Bump version to 0.10

### DIFF
--- a/macrostep.el
+++ b/macrostep.el
@@ -6,7 +6,7 @@
 ;; Maintainer: joddie <j.j.oddie@gmail.com>
 ;; Created:    16 January 2012
 ;; Updated:    07 December 2015
-;; Version:    0.9
+;; Version:    0.10
 ;; Keywords:   lisp, languages, macro, debugging
 ;; Url:        https://github.com/joddie/macrostep
 ;; Package-Requires: ((cl-lib "0.5"))


### PR DESCRIPTION
In case you did not already see this, `macrostep` is now available on [NonGNU ELPA](http://elpa.nongnu.org/nongnu/macrostep.html). In that ELPA archive, releases are only made when the "Version" header is increased. This means that it is currently distributing an old version from 2015 without the latest fixes.

Please consider bumping the version number to 0.10 to trigger a release of the latest version there.

Thanks!